### PR TITLE
issue-175 walk around attaching preview container issue. When initPre…

### DIFF
--- a/search-parts/src/webparts/searchResults/components/Layouts/SearchResultsTemplate.tsx
+++ b/search-parts/src/webparts/searchResults/components/Layouts/SearchResultsTemplate.tsx
@@ -29,7 +29,9 @@ export default class SearchResultsTemplate extends React.Component<ISearchResult
 
     public componentDidUpdate() {
         // Post render operations (previews on elements, etc.)
-        TemplateService.initPreviewElements();  
+        setTimeout(() => {
+            TemplateService.initPreviewElements();  
+        }, 1);
     }
 
     public UNSAFE_componentWillReceiveProps(nextProps: ISearchResultsTemplateProps) {


### PR DESCRIPTION
…viewElements is called, no results are present in the DOM yet. Walk around is to call initPreviewElements inside a dummy setTimeout function